### PR TITLE
Remove 'npm run install' from instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ upstream        git@github.com:cds-snc/node-starter-app.git (push)
 
 ```bash
 npm install
-npm run install
 npm run dev
 ```
 


### PR DESCRIPTION
I think there's just a tiny mistake in the setup instructions. Removed the command that caused the error.

![image](https://user-images.githubusercontent.com/950486/64562630-61ce5280-d31b-11e9-96de-d2d3a0471807.png)
