### PR TITLE
Fix notify_type validatation in example

### DIFF
--- a/routes/personal/schema.js
+++ b/routes/personal/schema.js
@@ -38,8 +38,7 @@ const Schema = {
   notify_type: {
     custom: {
       options: (value, { req }) => {
-        console.log("val",value)
-        //return isValidDate(value);
+        return ( value === "SMS" || value === "Email" )
       },
       errorMessage: "errors.notify_type"
     }


### PR DESCRIPTION
Fixes the Personal Information example, where notification preference always comes back invalid.

![image](https://user-images.githubusercontent.com/950486/64567578-8e3b9c00-d326-11e9-80f8-58de8f8ba5f5.png)
