### PR TITLE
Pass route name to doRedirect via middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,11 @@ Note: Delete unused route(s) directories as needed.
 
 ## Passing data to views
 
-Saved data is available via getSessionData(req) or getViewData(req, name)
+Saved data is available via getSessionData(req) or getViewData(req)
 
 ```javascript
 app.get(route.path, (req, res) => {
-  res.render(name, routeUtils.getViewData(req, name));
+  res.render(name, routeUtils.getViewData(req));
 });
 ```
 

--- a/bin/route/{{sample}}/{{sample}}.controller.js
+++ b/bin/route/{{sample}}/{{sample}}.controller.js
@@ -10,7 +10,7 @@ module.exports = app => {
 
   app
     .get(route.path, (req, res) => {
-      res.render(name, routeUtils.getViewData(req, name));
+      res.render(name, routeUtils.getViewData(req));
     })
     .post(route.path, [
       ...routeUtils.getDefaultMiddleware({ schema: Schema, name: name })

--- a/locales/en.json
+++ b/locales/en.json
@@ -46,5 +46,11 @@
   "form.address": "Address",
   "form.address.desc": "Enter your current address",
   "errors.send_notifications.valid": "errors.send_notifications.valid",
-  "errors.notify_type": "errors.notify_type"
+  "errors.notify_type": "errors.notify_type",
+  "Cannot read property 'length' of undefined": "Cannot read property 'length' of undefined",
+  "test": "test",
+  "dsfdsf": "dsfdsf",
+  "value 111": "value 111",
+  "TEXTDFDF": "TEXTDFDF",
+  "TEXT 111": "TEXT 111"
 }

--- a/routes/personal/personal.controller.js
+++ b/routes/personal/personal.controller.js
@@ -10,7 +10,7 @@ module.exports = app => {
 
   app
     .get(route.path, (req, res) => {
-      res.render(name, routeUtils.getViewData(req, name));
+      res.render(name, routeUtils.getViewData(req));
     })
     .post(route.path, [
       ...routeUtils.getDefaultMiddleware({ schema: Schema, name: name })

--- a/routes/personal/personal.pug
+++ b/routes/personal/personal.pug
@@ -17,9 +17,9 @@ block content
 
     +textInput('form.passport_expiry', null, 'form.passport_expiry.desc')(class='w-3-4', id='expiry' name='expiry', autofocus, value=data.expiry)
     
-    +textArea('form.address', null, 'form.address.desc')(class='w-3-4', id='address' name='address', autofocus, value=data.address)
+    +textArea('form.address', null, 'form.address.desc', data.address)(class='w-3-4', id='address' name='address', autofocus)
     
-    +radioButtons('send_notifications', {1:'Yes',2:'No'}, data.card_type, 'form.send_notifications', errors)
+    +radioButtons('send_notifications', {1:'Yes',2:'No'}, data.send_notifications, 'form.send_notifications', errors)
     
     +checkBoxes('notify_type', {1:'SMS',2:'Email'}, data.notify_type, 'form.notify_by', errors)
 

--- a/routes/personal/personal.pug
+++ b/routes/personal/personal.pug
@@ -23,7 +23,4 @@ block content
     
     +checkBoxes('notify_type', {1:'SMS',2:'Email'}, data.notify_type, 'form.notify_by', errors)
 
-    input(name='name', type='hidden', value=name)
-    input(name='nonce', type='hidden', value=nonce)
-
     +formButtons()

--- a/routes/personal/schema.js
+++ b/routes/personal/schema.js
@@ -34,16 +34,23 @@ const Schema = {
       options: [["Yes", "No"]]
     }
   },
-
   notify_type: {
     custom: {
       options: (value, { req }) => {
-        console.log("val",value)
-        //return isValidDate(value);
+        const send_notifications = req.body.send_notifications;
+        if (send_notifications && send_notifications === "Yes") {
+          if (typeof value === "undefined") {
+            return false;
+          }
+        } else {
+          req.body.notify_type = undefined;
+        }
+
+        return true;
       },
       errorMessage: "errors.notify_type"
     }
-  },
+  }
 };
 
 module.exports = {

--- a/utils/data.helpers.js
+++ b/utils/data.helpers.js
@@ -2,10 +2,9 @@ const { getSessionData } = require("./session.helpers");
 const { getFlashMessage } = require("./flash.message.helpers");
 const { generateNonce } = require("./validate.helpers");
 
-const getViewData = (req, name) => {
+const getViewData = req => {
   const params = {
     data: getSessionData(req),
-    name,
     nonce: generateNonce()
   };
 

--- a/utils/route.helpers.js
+++ b/utils/route.helpers.js
@@ -19,18 +19,20 @@ const checkPublic = function(req, res, next) {
 /**
  * attempt to auto redirect based on the next route it the route config
  */
-const doRedirect = (req, res, next) => {
-  if (req.body.json) {
-    return next();
-  }
+const doRedirect = routeName => {
+  return (req, res, next) => {
+    if (req.body.json) {
+      return next();
+    }
 
-  const nextRoute = getNextRoute(req.body.name);
+    const nextRoute = getNextRoute(routeName);
 
-  if (!nextRoute.path) {
-    throw new Error(`[POST ${req.path}] 'redirect' missing`);
-  }
+    if (!nextRoute.path) {
+      throw new Error(`[POST ${req.path}] 'redirect' missing`);
+    }
 
-  return res.redirect(nextRoute.path);
+    return res.redirect(nextRoute.path);
+  };
 };
 
 /**
@@ -42,9 +44,7 @@ const getPreviousRoute = (name, routes = defaultRoutes) => {
   const route = getRouteWithIndexByName(name, routes);
 
   if (!route || (!"index" in route && process.env.NODE_ENV !== "production")) {
-    throw new Error(
-      "Next route error.  \n Did you miss the name input in your form? \n i.e. input(name='name', type='hidden', value=name)"
-    );
+    throw new Error(`Previous route error can't find => "${name}"`);
   }
 
   const prevRoute = routes[Number(route.index) - 1]
@@ -67,9 +67,7 @@ const getNextRoute = (name, routes = defaultRoutes) => {
   const route = getRouteWithIndexByName(name, routes);
 
   if (!route || (!"index" in route && process.env.NODE_ENV !== "production")) {
-    throw new Error(
-      "Next route error.  \n Did you miss the name input in your form? \n i.e. input(name='name', type='hidden', value=name)"
-    );
+    throw new Error(`Next route error can't find => "${name}"`);
   }
 
   const nextRoute = routes[Number(route.index) + 1]
@@ -118,7 +116,7 @@ const getDefaultMiddleware = options => {
     checkNonce,
     checkSchema(options.schema),
     checkErrors(options.name),
-    doRedirect
+    doRedirect(options.name)
   ];
 };
 

--- a/utils/route.helpers.spec.js
+++ b/utils/route.helpers.spec.js
@@ -58,28 +58,38 @@ test("getNextRoute will throw an error when missing params", () => {
   }).toThrow();
 });
 
-test("Calls redirect if it finds the next route", () => {
-  const req = { body: { name: "start" } };
-  const next = jest.fn();
-  const redirectMock = jest.fn();
-  const res = {
-    query: {},
-    headers: {},
-    data: null,
-    redirect: () => {
-      redirectMock();
-    }
+describe("doRedirect", () => {
+  const runMiddleWare = routeName => {
+    return (req, res, next) => {
+      return doRedirect(routeName)(req, res, next);
+    };
   };
-  doRedirect(req, res, next);
-  expect(next.mock.calls.length).toBe(0);
-  expect(redirectMock.mock.calls.length).toBe(1);
-});
 
-test("Calls next if json is requested", () => {
-  const req = { body: { json: true } };
-  const next = jest.fn();
-  doRedirect(req, {}, next);
-  expect(next.mock.calls.length).toBe(1);
+  test("Calls redirect if it finds the next route", () => {
+    const req = { body: {} };
+    const next = jest.fn();
+    const redirectMock = jest.fn();
+    const res = {
+      query: {},
+      headers: {},
+      data: null,
+      redirect: () => {
+        redirectMock();
+      }
+    };
+
+    runMiddleWare("start")(req, res, next);
+    expect(next.mock.calls.length).toBe(0);
+    expect(redirectMock.mock.calls.length).toBe(1);
+  });
+
+  test("Calls next if json is requested", () => {
+    const req = { body: { json: true } };
+    const next = jest.fn();
+    const res = {};
+    runMiddleWare("start")(req, res, next);
+    expect(next.mock.calls.length).toBe(1);
+  });
 });
 
 test("Can retreive an array of middleware", () => {

--- a/views/_includes/checkboxes.pug
+++ b/views/_includes/checkboxes.pug
@@ -1,12 +1,18 @@
-mixin checkBoxes(key, values, value, question, errors = false)
+- var hasValue = function (values, val) {
+-   if(!values || !values.length) return false
+-   return values.includes(val)
+- }
+
+mixin checkBoxes(key, values, selectedVals, question, errors = false)
   div(class={['has-error']: errors && errors[key]})
-    fieldset.fieldset
+    fieldset.fieldset(id=key)
       legend.fieldset__legend #{__(question)}
       .multiple-choice.multiple-choice--checkboxes
         if errors && errors[key] && errors[key].msg
           +validationMessage(errors[key].msg, key)
         
         each val, index in values
+          - var selected = hasValue(selectedVals, val)
           .multiple-choice__item
-            input(id=`${key}${val}` name=key type="checkbox" value=`${val}` checked=(value ==`${val}`) aria-describedby=(errors ? `${key}-error` : false))
+            input(id=`${key}${val}` name=key type="checkbox" value=`${val}` checked=(selected) aria-describedby=(errors ? `${key}-error` : false))
             label(for=`${key}${val}`) #{`${val}`}

--- a/views/_includes/input-textarea.pug
+++ b/views/_includes/input-textarea.pug
@@ -4,7 +4,7 @@
 if errors
   -var firstError = errors[Object.keys(errors)[0]]
 
-mixin textArea(label, divClasses, hintText)
+mixin textArea(label, divClasses, hintText, value)
   div(
     class={['has-error']: errors && errors[attributes.name]}
     class=divClasses
@@ -30,4 +30,4 @@ mixin textArea(label, divClasses, hintText)
       id=(attributes.id || attributes.name)
       aria-describedby=(errors && errors[attributes.name] ? attributes.name + '-error' : false)
       autofocus=(errors && firstError.param === attributes.name ? true : false)
-    )&attributes(attributes)
+    )&attributes(attributes) !{value}


### PR DESCRIPTION
Updates doRedirect to pass routeName via middleware vs hidden form.

Route names used to have to be passed via a hidden form input:
``` javascript
input(name='name', type='hidden', value=name)
```

This is now handled via middleware

```diff
getDefaultMiddleware = options => {
    checkNonce,
    checkSchema(options.schema),
    checkErrors(options.name),
-   doRedirect
+   doRedirect(options.name)
```