### PR TITLE
Update CSS for the language switching link

### DIFF
--- a/public/scss/components/_header.scss
+++ b/public/scss/components/_header.scss
@@ -23,10 +23,15 @@ header {
   .language-link {
     text-align: left;
     margin-bottom: $space-sm;
-    font-size: 0.9em;
 
     h2 {
       @include visuallyHidden();
+    }
+
+    form, button {
+      margin: 0;
+      max-width: unset;
+      width: auto;
     }
 
     button {
@@ -34,6 +39,13 @@ header {
       color: $color-blue-dark;
       text-decoration: underline;
       border: 0;
+
+      box-shadow: none;
+      font-size: 0.9em;
+
+      &:focus {
+        @include focus(3px, 3px);
+      }
     }
 
     @include sm {


### PR DESCRIPTION
Ever since making the `<form>` CSS generic, the language-switching link (actually a button) had a bunch of new styles to it and it looked kind of broken -- particularly on mobile.

Updated the "header" CSS to fix the styling for the language link.

## Screenshots

| before | after |
|--------|-------|
|  language link is dropped below the Canada header (because <form> is a block element) and it has a double undeline (ie, box-shadow)    |  language link is flush with the top of the Canada header 👍 |
|  <img width="1239" alt="Screen Shot 2019-09-10 at 4 09 27 PM" src="https://user-images.githubusercontent.com/2454380/64646676-8b53b080-d3e5-11e9-853b-cf5345939117.png">  |   <img width="1239" alt="Screen Shot 2019-09-10 at 4 09 24 PM" src="https://user-images.githubusercontent.com/2454380/64646680-8d1d7400-d3e5-11e9-905d-61a74d098aa5.png">   |
|  form has lots of margin and is full width + box-shadow looks like a bottom underline  |  button + form have no margin and box-shadow is removed  👍   |
|  <img width="612" alt="Screen Shot 2019-09-10 at 4 09 35 PM" src="https://user-images.githubusercontent.com/2454380/64646669-8858c000-d3e5-11e9-81d6-fe8d96554379.png">  |  <img width="612" alt="Screen Shot 2019-09-10 at 4 09 33 PM" src="https://user-images.githubusercontent.com/2454380/64646673-8a228380-d3e5-11e9-936a-f88a49f79d44.png">  |





