### PR TITLE
Fix flash message mock to return proper structure

### DIFF
--- a/routes/personal/personal.controller.spec.js
+++ b/routes/personal/personal.controller.spec.js
@@ -17,11 +17,11 @@ test('Can send post request personal route ', async () => {
 
 jest.mock('../../utils/flash.message.helpers', () => ({
   getFlashMessage: jest.fn(req => {
-    return [{ param: 'testerror', msg: 'caught this error' }]
+    return { fieldname: { value: '', msg: 'caught this error', param: 'testerror', location: 'body' } }
   }),
 }))
 
-test.skip('Display errors on the page', async () => {
+test('Display errors on the page', async () => {
   const route = getRouteByName('personal')
   const response = await request(app).get(route.path)
   expect(response.statusCode).toBe(200)


### PR DESCRIPTION
This fixes a failing test leftover from the conversion to Nunjucks templates.

The Flash Message mock in the personal.controller test was returning an array of error objects, but the structure was wrong. The actual flash message comes back as an object of error objects.

ie, the mock was returning this:

```
[
    { 
        param: 'testerror', 
        msg: 'caught this error' 
    }
]
```

but the flash message for form errors is actually this:

```
{ 
    fieldname: { 
        value: '', 
        msg: 'caught this error', 
        param: 'testerror', 
        location: 'body' 
    } 
}
```

I assume this was failing in nunjucks but not pug due to differences in array/object loop syntax.