### PR TITLE
Add skip to main content link

### DIFF
--- a/assets/scss/components/_skip-link.scss
+++ b/assets/scss/components/_skip-link.scss
@@ -1,0 +1,38 @@
+.skip-link {
+    position:absolute !important;
+    width:1px !important;
+    height:1px !important;
+    margin:0 !important;
+    overflow:hidden !important;
+    clip:rect(0 0 0 0) !important;
+    -webkit-clip-path:inset(50%) !important;
+    clip-path:inset(50%) !important;
+    white-space:nowrap !important;
+    -webkit-font-smoothing:antialiased;
+    -moz-osx-font-smoothing:grayscale;
+    font-size:14px;
+    font-size:.875rem;
+    line-height:1.14286;
+    display:block;
+    padding:10px 15px
+}
+.skip-link:active,.skip-link:focus{
+    position:static !important;
+    width:auto !important;
+    height:auto !important;
+    margin:inherit !important;
+    overflow:visible !important;
+    clip:auto !important;
+    -webkit-clip-path:none !important;
+    clip-path:none !important;
+    white-space:inherit !important
+}
+
+.skip-link:link,.skip-link:visited,.skip-link:hover,.skip-link:active,.skip-link:focus {
+    color:#0b0c0c
+}
+
+.skip-link:focus{
+    outline:3px solid $color-yellow;
+    background-color:$color-yellow;
+}

--- a/assets/scss/styles.scss
+++ b/assets/scss/styles.scss
@@ -20,3 +20,4 @@
 @import './components/_breakdown-table';
 @import './components/_phase-banner';
 @import './components/_input-file';
+@import './components/skip-link';

--- a/locales/en.json
+++ b/locales/en.json
@@ -3,6 +3,7 @@
   "500": "500",
   "app.title": "Node Starter App",
   "phase.desc": "This site will change as we test ideas.",
+  "Skip to main content": "Skip to main content",
   "Language Selection": "Language Selection",
   "Language selection: French": "Language selection: French",
   "start.title": "Node Starter App",

--- a/views/base.njk
+++ b/views/base.njk
@@ -21,12 +21,13 @@
         <title>{{ __('app.title') }}</title>
     </head>
     <body>
+        <a class="skip-link" href="#content">{{ __('Skip to main content') }}</a>
         <div class="container">
             <header>
                 {% include "_includes/phaseBanner.njk" %}
                 {% include "_includes/fip.njk" %}
             </header>
-            <main>
+            <main id="content">
                 {% if errors %}
                     {% include "_includes/errorList.njk" %}
                 {% endif %}


### PR DESCRIPTION
- Adds a "Skip to main content" hidden link at the top of the page (becomes visible on focus)
- Style/markup mostly stolen from [Gov.UK design system version of same](https://github.com/alphagov/govuk-frontend/tree/master/package/govuk/components/skip-link).
- See also: https://webaim.org/techniques/skipnav/

![image](https://user-images.githubusercontent.com/1187115/65349826-577d4580-dbb2-11e9-8535-4e5f9b168841.png)
