### PR TITLE
run textarea hint text through i18n

### DIFF
--- a/views/macros/input-textarea.njk
+++ b/views/macros/input-textarea.njk
@@ -11,7 +11,7 @@
     <div class="{{ 'has-error' if errors and errors[attributes.name] }} {{ divClasses }}">
         <label for="{{ attributes.name }}" id="{{ attributes.name }}__label">{{ __(label) }}</label>
         {% if hintText %}
-            <span class="form-message">{{ hintText }}</span>
+            <span class="form-message">{{ __(hintText) }}</span>
         {% endif %}
         {% if errors and errors[attributes.name] %}
             {{ validationMessage(errors[attributes.name].msg, attributes.name) }}


### PR DESCRIPTION
fixes #59 

`textarea`'s hint text wasn't being run through i18n.