### PR TITLE
Simplify getViewData + getDefaultMiddleware 

### DIFF
--- a/routes/confirmation/confirmation.controller.js
+++ b/routes/confirmation/confirmation.controller.js
@@ -4,6 +4,7 @@ const {
   getSessionData,
   getRouteByName,
   addViewPath,
+  getViewData,
   // setFlashMessageContent,
 } = require('../../utils/index')
 
@@ -26,6 +27,6 @@ module.exports = app => {
     }
     */
 
-    res.render(name, { data: getSessionData(req) })
+    res.render(name, getViewData(req))
   })
 }

--- a/routes/confirmation/confirmation.controller.js
+++ b/routes/confirmation/confirmation.controller.js
@@ -1,7 +1,6 @@
 const path = require('path')
 const {
   // validateRouteData,
-  getSessionData,
   getRouteByName,
   addViewPath,
   getViewData,

--- a/routes/personal/personal.controller.js
+++ b/routes/personal/personal.controller.js
@@ -11,9 +11,10 @@ module.exports = app => {
   app
     .get(route.path, (req, res) => {
       const jsFiles = ['js/file-input.js']
-      res.render(name, { ...routeUtils.getViewData(req), jsFiles })
+      res.render(name, routeUtils.getViewData(req, jsFiles))
     })
-    .post(route.path, [
-      ...routeUtils.getDefaultMiddleware({ schema: Schema, name: name }),
-    ])
+    .post(
+      route.path,
+      routeUtils.getDefaultMiddleware({ schema: Schema, name: name }),
+    )
 }

--- a/routes/start/start.controller.js
+++ b/routes/start/start.controller.js
@@ -1,5 +1,6 @@
 const path = require('path')
 const {
+  routeUtils,
   getNextRoute,
   getRouteByName,
   addViewPath,
@@ -14,9 +15,23 @@ module.exports = app => {
 
   // redirect from "/" → "/start"
   app.get('/', (req, res) => res.redirect(route.path))
+
   app.get(route.path, async (req, res) => {
+    // adding JS files with
+    // getClientJs will look for a generated js file
+    // based on the route name
+
+    // or you can supply an array
+    // ['js/file-input.js']
     const jsPath = getClientJs(req, name)
     const jsFiles = jsPath ? [jsPath] : false
-    res.render(name, { nextRoute: getNextRoute(name).path, jsFiles })
+
+    res.render(
+      name,
+      routeUtils.getViewData(res, {
+        nextRoute: getNextRoute(name).path,
+        jsFiles,
+      }),
+    )
   })
 }

--- a/utils/data.helpers.js
+++ b/utils/data.helpers.js
@@ -3,7 +3,7 @@ const { getFlashMessage } = require('./flash.message.helpers')
 
 const getViewData = (req, optionalParams = {}) => {
   const params = {
-    data: { ...getSessionData(req), ...optionalParams },
+    data: { ...getSessionData(req) },
   }
 
   const errors = getFlashMessage(req)
@@ -12,7 +12,7 @@ const getViewData = (req, optionalParams = {}) => {
     params.errors = errors
   }
 
-  return params
+  return { ...params, ...optionalParams }
 }
 
 module.exports = {

--- a/utils/data.helpers.spec.js
+++ b/utils/data.helpers.spec.js
@@ -22,3 +22,16 @@ test('populates session and includes errors', () => {
   expect(obj.data.code).toEqual('123')
   expect(obj.errors).toEqual('the error')
 })
+
+test('returns an object with additional params', () => {
+  const req = {
+    body: {},
+    session: { formdata: { code: '123' } },
+    headers: { host: 'localhost' },
+  }
+
+  const obj = getViewData(req, { file1: 'hello.js', file2: 'goodbye.js' })
+  expect(obj.data.code).toEqual('123')
+  expect(obj.file1).toEqual('hello.js')
+  expect(obj.file2).toEqual('goodbye.js')
+})

--- a/utils/flash.message.helpers.js
+++ b/utils/flash.message.helpers.js
@@ -1,6 +1,7 @@
 // ⚠️ experimental
 
 const getFlashMessage = req => {
+  if (!req || !req.session) return null
   const message = req.session.flashmessage
   clearFlashMessageContent(req)
   return message

--- a/utils/session.helpers.js
+++ b/utils/session.helpers.js
@@ -1,4 +1,5 @@
 const getSessionData = req => {
+  if (!req.session) return {}
   return typeof req.session.formdata === 'object' ? req.session.formdata : {}
 }
 


### PR DESCRIPTION
Simplify getViewData + getDefaultMiddleware to remove the JS spread operator from the route code

You can now use 
```
routeUtils.getViewData(req, customVars)
```
vs
```
 { ...routeUtils.getViewData(req), jsFiles }
```
and
```
routeUtils.getDefaultMiddleware({ schema: Schema, name: name })
```
vs
```
[ ...routeUtils.getDefaultMiddleware({ schema: Schema, name: name }) ]
```

Closes https://github.com/cds-snc/node-starter-app/issues/64