### PR TITLE
Add nunjucks spread params filter

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,6 +11,7 @@ const path = require('path')
 const cookieSession = require('cookie-session')
 const cookieSessionConfig = require('./config/cookieSession.config')
 const { hasData, checkPublic, checkLangQuery } = require('./utils')
+const { addNunjucksFilters } = require('./filters')
 const csp = require('./config/csp.config')
 const csrf = require('csurf')
 
@@ -99,11 +100,7 @@ const env = nunjucks
   })
   .addGlobal('$env', process.env)
 
-env.addFilter('shorten', function(str, count) {
-  return str.slice(0, count || 2)
-})
-
-//
+addNunjucksFilters(env)
 
 nunjucks.installJinjaCompat()
 

--- a/app.js
+++ b/app.js
@@ -12,13 +12,13 @@ const cookieSession = require('cookie-session')
 const cookieSessionConfig = require('./config/cookieSession.config')
 const { hasData, checkPublic, checkLangQuery } = require('./utils')
 const csp = require('./config/csp.config')
-const csrf = require('csurf');
+const csrf = require('csurf')
 
 // check to see if we have a custom configRoutes function
-let { configRoutes, routes } = require('./config/routes.config')
+let { configRoutes, routes } = require('./config/routes.config') // test mock sets as undefined but says line isn't covered
 
-/* istanbul ignore next */ // test mock sets as undefined but says line isn't covered
-if (typeof configRoutes === 'undefined') { // if not use the default
+/* istanbul ignore next */ if (typeof configRoutes === 'undefined') {
+  // if not use the default
   configRoutes = require('./utils/route.helpers').configRoutes
 }
 
@@ -32,13 +32,15 @@ app.use(cookieParser(process.env.app_session_secret))
 app.use(require('./config/i18n.config').init)
 
 // CSRF setup
-app.use(csrf({
-  cookie: true,
-  signed: true,
-}))
+app.use(
+  csrf({
+    cookie: true,
+    signed: true,
+  }),
+)
 
 // append csrfToken to all responses
-app.use(function (req, res, next) {
+app.use(function(req, res, next) {
   res.locals.csrfToken = req.csrfToken()
   next()
 })
@@ -82,21 +84,29 @@ app.locals.GITHUB_SHA = process.env.GITHUB_SHA || null
 app.locals.hasData = hasData
 
 // set default views path
-app.locals.basedir = path.join(__dirname, "./views");
-app.set("views", [path.join(__dirname, "./views")]);
+app.locals.basedir = path.join(__dirname, './views')
+app.set('views', [path.join(__dirname, './views')])
 
 configRoutes(app, routes)
 
 // view engine setup
-const nunjucks = require("nunjucks");
+const nunjucks = require('nunjucks')
 
-nunjucks.configure([...app.get("views"), 'views/macros'], {
-  autoescape: true,
-  express: app,
-}).addGlobal('$env', process.env);
+const env = nunjucks
+  .configure([...app.get('views'), 'views/macros'], {
+    autoescape: true,
+    express: app,
+  })
+  .addGlobal('$env', process.env)
 
-nunjucks.installJinjaCompat();
+env.addFilter('shorten', function(str, count) {
+  return str.slice(0, count || 2)
+})
 
-app.set('view engine', 'njk');
+//
 
-module.exports = app;
+nunjucks.installJinjaCompat()
+
+app.set('view engine', 'njk')
+
+module.exports = app

--- a/filters/index.js
+++ b/filters/index.js
@@ -1,0 +1,9 @@
+const { spreadParams } = require('./spreadParams')
+
+const addNunjucksFilters = env => {
+  spreadParams(env)
+}
+
+module.exports = {
+  addNunjucksFilters,
+}

--- a/filters/spreadParams.js
+++ b/filters/spreadParams.js
@@ -1,0 +1,17 @@
+const spreadParams = env => {
+  env.addFilter('spreadParams', function(str, params) {
+    let paramsStr = ''
+
+    for (var property in params) {
+      if (params.hasOwnProperty(property)) {
+        paramsStr += ` ${property}=${params[property]} `
+      }
+    }
+
+    return `${paramsStr}`
+  })
+}
+
+module.exports = {
+  spreadParams,
+}

--- a/routes/start/start.njk
+++ b/routes/start/start.njk
@@ -8,6 +8,8 @@
 
     <div>{{ __('start.intro') | safe }}</div>
 
+    <p>A message for you: {{ "hello"|shorten }} </p>
+
     <div>
         <a class="button-link" href="{{ nextRoute }}" role="button" draggable="false">
             {{ __('start.submit') }}

--- a/routes/start/start.njk
+++ b/routes/start/start.njk
@@ -8,8 +8,8 @@
 
     <div>{{ __('start.intro') | safe }}</div>
 
-    <p>A message for you: {{ "hello"|shorten }} </p>
-
+    <p>Sample input that accepts arbitrary params:</p>
+    {{ sampleInput({"class": "error", "data-arr1":"data-1","data-arr2":"data-2"}) }}
     <div>
         <a class="button-link" href="{{ nextRoute }}" role="button" draggable="false">
             {{ __('start.submit') }}

--- a/views/base.njk
+++ b/views/base.njk
@@ -5,6 +5,7 @@
 {% from 'checkboxes.njk' import checkBoxes as checkBoxes with context %}
 {% from 'buttons.njk' import formButtons as formButtons with context %}
 {% from 'input-file.njk' import fileInput as fileInput with context %}
+{% from 'input-sample.njk' import sampleInput as sampleInput with context %}
 
 <!DOCTYPE html>
 <html lang="{{ 'en' if getLocale() === 'fr' else 'en' }}">

--- a/views/macros/input-sample.njk
+++ b/views/macros/input-sample.njk
@@ -1,0 +1,5 @@
+{% macro sampleInput(obj) %}
+    <div {{""|spreadParams(obj) }}>
+        your text
+    </div>
+{% endmacro %}


### PR DESCRIPTION
Added a filter to open up the possibility of using arbitrary params.

We could filter out to use only data- params for safety.

See this link for output https://cds-node-starter-pr-69.herokuapp.com/start

Will remove the sampleInput later

```nunjucks
 {{ sampleInput({"class": "error", "data-arr1":"data-1","data-arr2":"data-2"}) }}
```

```nunjucks
{% macro sampleInput(obj) %}
    <div {{""|spreadParams(obj) }}>
        your text
    </div>
{% endmacro %}
```

Outputs

```html
<div class="error" data-arr1="data-1" data-arr2="data-2">
  your text
</div>
```


