### PR TITLE
Don't save _csrf or redirect form values to session

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,8 +3,9 @@
 ## [4.0.1] - 2019-10-02
 ### Updated
 Linting rules + include utils directory
+Don't save `redirect` or `csrf` form data to session
 
-### Added 
+### Added
 Husky git hooks
 
 
@@ -58,5 +59,5 @@ app
 
 ## [2.2.1] - 2019-09-26
 ### Added
-- filter spreadParams for future use 
+- filter spreadParams for future use
   see: https://github.com/cds-snc/node-starter-app/pull/69

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-starter-app",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/utils/session.helpers.js
+++ b/utils/session.helpers.js
@@ -6,6 +6,9 @@ const getSessionData = req => {
 const saveSessionData = req => {
   // copy all posted parameters
   const body = Object.assign({}, req.body)
+  delete body.redirect
+  delete body._csrf
+
   req.session.formdata = { ...req.session.formdata, ...body }
 }
 

--- a/utils/session.helpers.spec.js
+++ b/utils/session.helpers.spec.js
@@ -1,11 +1,30 @@
 const { getSessionData, saveSessionData } = require('./session.helpers')
 
-test('Can get and set form data for the session', () => {
-  const req = {}
-  req.session = {}
-  req.body = { phone: '613-111-1111' }
-  expect(getSessionData(req)).toStrictEqual({})
-  saveSessionData(req)
-  expect(req.session.formdata).toStrictEqual(req.body)
-  expect(getSessionData(req)).toStrictEqual(req.body)
+const formVals = [
+  {
+    name: 'with generic values',
+    before: { phone: '613-111-1111' },
+    after: { phone: '613-111-1111' },
+  },
+  {
+    name: 'but NOT the _csrf key',
+    before: { phone: '613-111-1111', _csrf: '123' },
+    after: { phone: '613-111-1111' },
+  },
+  {
+    name: 'but NOT the redirect key',
+    before: { phone: '613-111-1111', redirect: '/end' },
+    after: { phone: '613-111-1111' },
+  },
+]
+formVals.map(formVal => {
+  test(`Can get and set form data for the session ${formVal.name}`, () => {
+    const req = {}
+    req.session = {}
+    req.body = formVal.before
+    expect(getSessionData(req)).toStrictEqual({})
+    saveSessionData(req)
+    expect(req.session.formdata).toStrictEqual(formVal.after)
+    expect(getSessionData(req)).toStrictEqual(formVal.after)
+  })
 })


### PR DESCRIPTION
We could save them if we wanted, but we probably don't need them.

I think

`We dont want to clutter the session` > `We don't want more logic`

So this is a pretty lightweight fix.

Resolves #93 