### PR TITLE
Flexible redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,20 +66,21 @@ Note: Delete unused route(s) directories as needed.
 
 ## Form step redirects
 
-Redirects are handled via doRedirect. The doRedirect function will do a look up for the next route based on the routes config. 
+Redirects are handled via `route.doRedirect()`. The doRedirect function will do a look up for the next route based on the routes config.
 
-For cases where the redirect is not straight forward you can handle manually.
+For cases where the redirect is not straight forward you can pass in a function, which can return a route name or a route object:
 
 ```javascript
-(req, res, next) => {
-  const confirm = req.body.confirm;
-  if (confirm === "Yes") {
-    const nextRoute = getNextRoute(name);
-    return res.redirect(nextRoute.path);
-  }
+// routes.config.js
+const routes = [
+  ...
+  { name: 'my-route', ..., skipTo: 'other-route' }
+  ...
+]
 
-  res.send("you said no");
-};
+// my-route.controller.js
+route.draw(app)
+  .post(..., route.doRedirect((req, res) => shouldSkip(req) ? route.skipTo : route.next))
 ```
 
 ## Form CSRF Protection

--- a/bin/route/[[sample]]/[[sample]].controller.js
+++ b/bin/route/[[sample]]/[[sample]].controller.js
@@ -5,8 +5,8 @@ module.exports = (app, route) => {
   const name = route.name
 
   route.draw(app)
-    .get(route.path, (req, res) => {
+    .get((req, res) => {
       res.render(name, routeUtils.getViewData(req, {}))
     })
-    .post(route.path, route.applySchema(Schema), route.doRedirect())
+    .post(route.applySchema(Schema), route.doRedirect())
 }

--- a/bin/route/[[sample]]/[[sample]].controller.js
+++ b/bin/route/[[sample]]/[[sample]].controller.js
@@ -8,5 +8,5 @@ module.exports = (app, route) => {
     .get(route.path, (req, res) => {
       res.render(name, routeUtils.getViewData(req, {}))
     })
-    .post(route.path, ...route.defaultMiddleware({ schema: Schema }))
+    .post(route.path, route.applySchema(Schema), route.doRedirect())
 }

--- a/routes/personal/personal.controller.js
+++ b/routes/personal/personal.controller.js
@@ -8,6 +8,7 @@ module.exports = (app, route) => {
       res.render(route.name, routeUtils.getViewData(req, jsFiles))
     })
     .post(
-      route.defaultMiddleware({ schema: Schema }),
+      route.applySchema(Schema),
+      route.doRedirect()
     )
 }

--- a/utils/route.helpers.js
+++ b/utils/route.helpers.js
@@ -179,20 +179,7 @@ const configRoutes = (app, routes, locales, opts={}) => {
   return makeRoutingTable(routes, locales, opts).config(app)
 }
 
-/**
- * attempt to auto redirect based on the next route it the route config
- */
-const doRedirect = route => {
-  return (req, res, next) => {
-    if (req.body.json) return next()
-    if (!route.path) throw new Error(`[POST ${req.path}] 'redirect' missing`)
-
-    return res.redirect(route.url(req.locale, req.query))
-  }
-}
-
 module.exports = {
   makeRoutingTable,
   configRoutes,
-  doRedirect,
 }

--- a/utils/route.helpers.js
+++ b/utils/route.helpers.js
@@ -105,10 +105,22 @@ class Route {
    */
   defaultMiddleware(opts) {
     return [
-      checkSchema(opts.schema),
-      checkErrors(this.name),
-      doRedirect(this.next),
+      ...applySchema(opts.schema),
+      this.doRedirect(opts.computeNext),
     ]
+  }
+
+  applySchema(schema) {
+    return [checkSchema(schema), checkErrors(this.name)]
+  }
+
+  doRedirect(redirectTo = null) {
+    return (req, res) => {
+      if (typeof redirectTo === 'function') redirectTo = redirectTo(req, res, this)
+      if (!redirectTo) redirectTo = this.next
+      if (typeof redirectTo === 'string') redirectTo = this.get(redirectTo)
+      res.redirect(redirectTo.url(req.locale))
+    }
   }
 }
 

--- a/utils/route.helpers.js
+++ b/utils/route.helpers.js
@@ -115,7 +115,9 @@ class Route {
   }
 
   doRedirect(redirectTo = null) {
-    return (req, res) => {
+    return (req, res, next) => {
+      if (req.body.json) return next()
+
       if (typeof redirectTo === 'function') redirectTo = redirectTo(req, res, this)
       if (!redirectTo) redirectTo = this.next
       if (typeof redirectTo === 'string') redirectTo = this.get(redirectTo)

--- a/utils/route.helpers.js
+++ b/utils/route.helpers.js
@@ -105,7 +105,7 @@ class Route {
    */
   defaultMiddleware(opts) {
     return [
-      ...applySchema(opts.schema),
+      ...this.applySchema(opts.schema),
       this.doRedirect(opts.computeNext),
     ]
   }

--- a/utils/route.helpers.spec.js
+++ b/utils/route.helpers.spec.js
@@ -48,31 +48,26 @@ describe('Routes', () => {
 })
 
 describe('doRedirect', () => {
+  const req = { body: {}, locale: 'fr' }
+  const next = jest.fn()
+  const redirectMock = jest.fn()
+  const res = {
+    query: {},
+    headers: {},
+    data: null,
+    redirect: redirectMock
+  }
+
   test('Calls redirect if it finds the next route', () => {
-    const route = testRoutes.get('personal')
-
-    const req = { body: {} }
-    const next = jest.fn()
-    const redirectMock = jest.fn()
-    const res = {
-      query: {},
-      headers: {},
-      data: null,
-      redirect: () => {
-        redirectMock()
-      },
-    }
-
-    doRedirect(route)(req, res, next)
+    personal.doRedirect()(req, res, next)
     expect(next.mock.calls.length).toBe(0)
     expect(redirectMock.mock.calls.length).toBe(1)
+    expect(redirectMock.mock.calls[0][0]).toEqual('/fr/confirmation')
   })
 
   test('Calls next if json is requested', () => {
-    const req = { body: { json: true } }
-    const next = jest.fn()
-    const res = {}
-    doRedirect(testRoutes.get('confirmation'))(req, res, next)
+    jsonReq = { ...req, body: { json: true } }
+    confirmation.doRedirect()(jsonReq, res, next)
     expect(next.mock.calls.length).toBe(1)
   })
 })

--- a/utils/route.helpers.spec.js
+++ b/utils/route.helpers.spec.js
@@ -1,4 +1,4 @@
-const { makeRoutingTable, doRedirect } = require('./index')
+const { makeRoutingTable } = require('./index')
 
 const testRoutes = makeRoutingTable(
   [
@@ -55,7 +55,7 @@ describe('doRedirect', () => {
     query: {},
     headers: {},
     data: null,
-    redirect: redirectMock
+    redirect: redirectMock,
   }
 
   test('Calls redirect if it finds the next route', () => {
@@ -66,7 +66,7 @@ describe('doRedirect', () => {
   })
 
   test('Calls next if json is requested', () => {
-    jsonReq = { ...req, body: { json: true } }
+    const jsonReq = { ...req, body: { json: true } }
     confirmation.doRedirect()(jsonReq, res, next)
     expect(next.mock.calls.length).toBe(1)
   })


### PR DESCRIPTION
Depends on #92. Factors out the `doRedirect` part of `defaultMiddleware`, and adds an `applySchema` function to do the rest. This allows request-time computation of the appropriate redirect *route*, which will be resolved to the correct path depending on the locale.