### PR TITLE
Remove pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npm run lint && npm test",
       "pre-push": "npm run lint && npm test"
     }
   },


### PR DESCRIPTION
The pre-commit was getting in the way.  The real intention was to catch linting and tests errors prior to pushing (avoiding the things failed because I forgot the dangling comma type of issue).

