### PR TITLE
Fix env issues for windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-starter-app",
-  "version": "4.0.1",
+  "version": "5.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2549,6 +2549,58 @@
       "dev": true,
       "requires": {
         "capture-stack-trace": "^1.0.0"
+      }
+    },
+    "cross-env": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-6.0.3.tgz",
+      "integrity": "sha512-+KqxF6LCvfhWvADcDPqo64yVIB31gv/jQulX2NGzKS/g3GEVz6/pt4wjHFtFWsHMddebWD/sDthJemzM4MaAag==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
+          "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.0.tgz",
+          "integrity": "sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.1.tgz",
+          "integrity": "sha512-N7GBZOTswtB9lkQBZA4+zAXrjEIWAUOB93AvzUiudRzRxhUdLURQ7D/gAIMY1gatT/LTbmbcv8SiYazy3eYB7w==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
       }
     },
     "cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -9,16 +9,16 @@
     "node": ">=10"
   },
   "scripts": {
-    "aws": "cd cdk && cdk synth && node deploy",
-    "aws-bootstrap": "node cdk/bootstrap.js",
-    "aws-destroy": "node cdk/destroy.js",
-    "dev": "NODE_ENV=development nodemon ./bin/www",
+    "dev": "cross-env NODE_ENV=development nodemon ./bin/www",
+    "start": "cross-env NODE_ENV=production node ./bin/www",
     "lint": "node node_modules/eslint/bin/eslint.js config utils routes bin/www app.js",
     "prettier": "prettier --write '**/*.{ts,js,css,html}'",
-    "start": "NODE_ENV=production node ./bin/www",
     "test": "node node_modules/jest/bin/jest.js --coverage",
     "test:watch": "node node_modules/jest/bin/jest.js --watch",
-    "postinstall": "patch-package"
+    "postinstall": "patch-package",
+    "aws": "cd cdk && cdk synth && node deploy",
+    "aws-bootstrap": "node cdk/bootstrap.js",
+    "aws-destroy": "node cdk/destroy.js"
   },
   "husky": {
     "hooks": {
@@ -45,16 +45,14 @@
     "request": "^2.88.0"
   },
   "devDependencies": {
-    "fse": "^4.0.1",
-    "husky": "^3.0.8",
-    "rimraf": "^3.0.0",
-    "acorn": "^7.1.0",
     "@aws-cdk/aws-docdb": "1.10.1",
     "@aws-cdk/aws-ec2": "1.10.1",
     "@aws-cdk/aws-ecs": "1.10.1",
     "@aws-cdk/aws-ecs-patterns": "1.10.1",
     "@aws-cdk/core": "1.10.1",
+    "acorn": "^7.1.0",
     "cheerio": "^1.0.0-rc.3",
+    "cross-env": "^6.0.3",
     "eslint": "^6.5.1",
     "eslint-config-prettier": "^6.3.0",
     "eslint-config-standard": "^14.1.0",
@@ -64,10 +62,13 @@
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-security": "^1.4.0",
     "eslint-plugin-standard": "^4.0.1",
+    "fse": "^4.0.1",
+    "husky": "^3.0.8",
     "jest": "^24.9.0",
     "nodemon": "^1.19.3",
     "patch-package": "^6.2.0",
     "prettier": "^1.18.2",
+    "rimraf": "^3.0.0",
     "supertest": "^4.0.2",
     "supertest-session": "^4.0.0"
   },


### PR DESCRIPTION
Setting environment variables in package.json was causing issues on Windows.
 

```
NODE_ENV=development nodemon ./bin/www
```

NODE_ENV is not recognized as an internal or external command, operable program or batch file.


This PR introduces cross-env 🔀to fix the issue.
```
Run scripts that set and use environment variables across platforms
```