### PR TITLE
Allow client js to load on heroku hosted apps

### DIFF
--- a/config/csp.config.js
+++ b/config/csp.config.js
@@ -1,6 +1,6 @@
 // docs: https://helmetjs.github.io/docs/csp/
 
-const scriptSrc = ["'self'", "'unsafe-inline'", 'cdnjs.cloudflare.com']
+const scriptSrc = ["'self'", "'unsafe-inline'", 'cdnjs.cloudflare.com', '*.herokuapp.com']
 
 if (process.env.NODE_ENV === 'development') {
   scriptSrc.push("'unsafe-eval'")
@@ -8,9 +8,10 @@ if (process.env.NODE_ENV === 'development') {
 
 module.exports = {
   defaultSrc: ["'self'"],
-  scriptSrc,
+  scriptSrc: scriptSrc,
   baseUri: ["'none'"],
   fontSrc: ["'self'", 'https://fonts.gstatic.com'],
   imgSrc: ["'self'", 'data:'],
   styleSrc: ["'self'", 'https://fonts.googleapis.com'],
+  upgradeInsecureRequests: true,
 }


### PR DESCRIPTION
This is a fix for https://github.com/cds-snc/single-point-of-access-prototype/issues/11