### PR TITLE
Improve route templates

### DIFF
--- a/bin/route/[[sample]]/[[sample]].njk
+++ b/bin/route/[[sample]]/[[sample]].njk
@@ -10,7 +10,9 @@
         </p>
 
         <form method="post">
-            {{ textInput('form.firstname', null, 'form.firstname.desc', { class: "w-3-4", name: "firstname", id: "firstname", autofocus: '', value: data.firstname }) }}
+            <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+            
+            {{ textInput('form.firstname', 'form.firstname.desc') }}
             {{ formButtons() }}
         </form>
     </div>

--- a/bin/route/[[sample]]/schema.js
+++ b/bin/route/[[sample]]/schema.js
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 const Schema = {
   firstname: {
     isLength: {

--- a/views/base.njk
+++ b/views/base.njk
@@ -1,10 +1,10 @@
-{% from 'validationMessage.njk' import validationMessage as validationMessage with context %}
-{% from 'input-text.njk' import textInput as textInput with context %}
-{% from 'input-textarea.njk' import textArea as textArea with context %}
-{% from 'radios.njk' import radioButtons as radioButtons with context %}
-{% from 'checkboxes.njk' import checkBoxes as checkBoxes with context %}
-{% from 'buttons.njk' import formButtons as formButtons with context %}
-{% from 'input-file.njk' import fileInput as fileInput with context %}
+{%- from 'validationMessage.njk' import validationMessage as validationMessage with context -%}
+{%- from 'input-text.njk' import textInput as textInput with context -%}
+{%- from 'input-textarea.njk' import textArea as textArea with context -%}
+{%- from 'radios.njk' import radioButtons as radioButtons with context -%}
+{%- from 'checkboxes.njk' import checkBoxes as checkBoxes with context -%}
+{%- from 'buttons.njk' import formButtons as formButtons with context -%}
+{%- from 'input-file.njk' import fileInput as fileInput with context -%}
 
 <!DOCTYPE html>
 <html lang="{{ 'en' if getLocale() === 'fr' else 'en' }}">


### PR DESCRIPTION
Fixes the route template to:
- fix the sample macro syntax so it renders
- add a csrf_token to the form

Also reduces whitespace at the top of html output, ie:
![image](https://user-images.githubusercontent.com/1187115/68434713-a5143880-0187-11ea-9d98-d7fe5349db24.png)
