### PR TITLE
Redirect back with errors

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [6.1.0] - 2019-11-25
+
+- Redirect back with errors. This *may* be a breaking change if you have written any customizations to deal with issues surrounding `renderPageWithErrors` in `validate.helpers.js`. That method has been removed, and now on validation errors, we flash the messages to the session and redirect back to the get route.
+
 ## [6.0.3] - 2019-11-22
 
 - Nodemon [2.0.1](https://github.com/remy/nodemon/releases/tag/v2.0.1) 

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,11 @@
 
 ## [6.1.0] - 2019-11-25
 
-- Redirect back with errors. This *may* be a breaking change if you have written any customizations to deal with issues surrounding `renderPageWithErrors` in `validate.helpers.js`. That method has been removed, and now on validation errors, we flash the messages to the session and redirect back to the get route.
+### Updated
+- Redirect back with errors. This *may* be a breaking change if you have written any customizations to deal with issues surrounding `renderPageWithErrors` in `validate.helpers.js`. That method has been removed, and now on validation errors, we flash the errors to the session and redirect back to the `get` route.
+
+### Removed
+- `renderPageWithErrors` has been removed from `validate.helpers.js`
 
 ## [6.0.3] - 2019-11-22
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## [6.1.0] - 2019-11-25
 
+### Updated
 - Redirect back with errors. This *may* be a breaking change if you have written any customizations to deal with issues surrounding `renderPageWithErrors` in `validate.helpers.js`.  That method has been removed, and now on validation errors, we flash the errors to the session and redirect back to the `get` route.
 
 ### Removed

--- a/changelog.md
+++ b/changelog.md
@@ -2,8 +2,7 @@
 
 ## [6.1.0] - 2019-11-25
 
-### Updated
-- Redirect back with errors. This *may* be a breaking change if you have written any customizations to deal with issues surrounding `renderPageWithErrors` in `validate.helpers.js`. That method has been removed, and now on validation errors, we flash the errors to the session and redirect back to the `get` route.
+- Redirect back with errors. This *may* be a breaking change if you have written any customizations to deal with issues surrounding `renderPageWithErrors` in `validate.helpers.js`.  That method has been removed, and now on validation errors, we flash the errors to the session and redirect back to the `get` route.
 
 ### Removed
 - `renderPageWithErrors` has been removed from `validate.helpers.js`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-starter-app",
-  "version": "6.0.3",
+  "version": "6.1.0",
   "description": "",
   "author": "CDS",
   "license": "MIT",

--- a/routes/personal/personal.controller.spec.js
+++ b/routes/personal/personal.controller.spec.js
@@ -25,7 +25,7 @@ test('Can send post request personal route ', async () => {
   const csrfToken = extractCsrfToken(getresp);
 
   const postresp = await testSession.post(route.path.en).send({ _csrf: csrfToken });
-  expect(postresp.statusCode).toBe(200);
+  expect(postresp.statusCode).toBe(302); // should redirect back with errors on an incomplete form
 })
 
 jest.mock('../../utils/flash.message.helpers', () => ({

--- a/utils/validate.helpers.js
+++ b/utils/validate.helpers.js
@@ -1,6 +1,5 @@
 const { validationResult, checkSchema } = require('express-validator')
 const { getSessionData, saveSessionData } = require('./session.helpers')
-const { setFlashMessageContent } = require('./flash.message.helpers')
 
 /*
   original format is an array of error objects: https://express-validator.github.io/docs/validation-result-api.html

--- a/utils/validate.helpers.js
+++ b/utils/validate.helpers.js
@@ -1,5 +1,6 @@
 const { validationResult, checkSchema } = require('express-validator')
 const { getSessionData, saveSessionData } = require('./session.helpers')
+const { setFlashMessageContent } = require('./flash.message.helpers')
 
 /*
   original format is an array of error objects: https://express-validator.github.io/docs/validation-result-api.html
@@ -64,43 +65,14 @@ const checkErrors = template => {
 
     saveSessionData(req)
 
+    // flash error messages and redirect back on error
     if (!errors.isEmpty()) {
-      return renderPageWithErrors(req, res, {
-        template,
-        errors: errorArray2ErrorObject(errors),
-      })
+      req.session.flashmessage = errorArray2ErrorObject(errors)
+      return res.redirect('back')
     }
 
     return next()
   }
-}
-
-/**
-* @param options template
- {
-        template: "personal",
-        errors: {
-          fullname: {
-            value: "",
-            msg: "errors.fullname.length",
-            param: "fullname",
-            location: "body"
-          }
-        }
-      };
- */
-
-const renderPageWithErrors = (
-  req,
-  res,
-  options = { template: '', errors: [] },
-) => {
-  return res.render(options.template, {
-    data: getSessionData(req),
-    name: options.template,
-    body: req.body,
-    errors: options.errors,
-  })
 }
 
 /**
@@ -127,12 +99,12 @@ const validateRouteData = async (req, schema) => {
   }
 
   // run checkSchema()
-  await middleWare[0][0](validateReq, res, () => {})
+  await middleWare[0][0](validateReq, res, () => { })
 
   // run checkErrors()
-  middleWare[1](validateReq, res, () => {})
+  middleWare[1](validateReq, res, () => { })
 
-  const errors = checkErrorsJSON(validateReq, res, () => {})
+  const errors = checkErrorsJSON(validateReq, res, () => { })
 
   if (!isEmptyObject(errors)) {
     return { status: false, errors: errors }
@@ -187,5 +159,4 @@ module.exports = {
   checkErrorsJSON,
   hasData,
   isEmptyObject,
-  renderPageWithErrors,
 }


### PR DESCRIPTION
Currently when posting a form with incomplete data, the validation helper takes over and re-renders the form with errors in place from the post route. This causes some problems, and is, I think, the root of the issue in #103

This will instead flash the error messages to the session, then redirect back to the form. Since the form re-renders as a regular GET request, it will have everything a GET request should have available to it. So this also solves the problem of page-specific js being lost on validation errors.

Had to adjust the test as well, since the response on an incomplete form request is now a 302 redirect instead of a 200 OK.