### PR TITLE
Fixed typo

### DIFF
--- a/routes/start/start.controller.js
+++ b/routes/start/start.controller.js
@@ -7,6 +7,6 @@ module.exports = (app, route) => {
   app.get('/', (req, res) => res.redirect(route.path[req.locale]))
 
   route.draw(app).get(async (req, res) => {
-    res.render(name, routeUtils.getViewData(res))
+    res.render(name, routeUtils.getViewData(req))
   })
 }


### PR DESCRIPTION
This is just a straight up typo. See the [function definition](https://github.com/cds-snc/node-starter-app/blob/master/utils/data.helpers.js#L4) in utils/data.helpers.js:

`const getViewData = (req, optionalParams = {}) => {`

I noticed this because it was causing client side js to not be loaded for the start page.

As far as I can tell this should not break any functionality for existing apps.