### PR TITLE
Add explicit max-height to svg container (for IE11)

### DIFF
--- a/assets/scss/components/_header.scss
+++ b/assets/scss/components/_header.scss
@@ -54,6 +54,8 @@ header {
   }
 
   .canada-flag {
+    height: auto;
+    min-height: 40px;
     width: 272px;
     margin-bottom: $space-sm;
 


### PR DESCRIPTION
On IE on Windows 7 and under, the height of the SVG in the header is far too large, even though it visually is the right size. (that is, there is a lot of whitespace underneath the img element.)

Checked how Canada.ca solves this problem and they set a max-height at 40px, which seems to work and isn't too complicated.

Looked up some Stackoverflow questions but they mostly had complicated fixes so gonna go with this instead.

## Screenshot

| before | after |
|--------|-------|
| <img width="1516" alt="Screen Shot 2019-12-10 at 9 42 13 AM" src="https://user-images.githubusercontent.com/2454380/70543315-35072280-1b38-11ea-8831-eb17587cc115.png">   | <img width="1475" alt="Screen Shot 2019-12-10 at 10 13 28 AM" src="https://user-images.githubusercontent.com/2454380/70543313-35072280-1b38-11ea-838d-b529a7951b74.png">   |

